### PR TITLE
Updated the Min & Max length defaults to 0.

### DIFF
--- a/ValidateThis/server/ServerRuleValidator_CollectionSize.cfc
+++ b/ValidateThis/server/ServerRuleValidator_CollectionSize.cfc
@@ -85,7 +85,7 @@
 				theSize = arrayLen(theVal);
 			}
 			
-			valid = theSize lt minLength or theSize gt maxLength;
+			valid = theSize lte minLength or theSize gte maxLength;
 			
 			if(not valid){
 				arrayAppend(args,minLength);


### PR DESCRIPTION
I'm not sure why the default min & max length for the collectionSize validation method was set to 1.  It seems to me that it makes more sense to have the validation start at 0.  I have a requirement to have my validation start at min 0 and max 0 so It seems like it makes sense to have the rule look like this:

``` xml
<property name="products">
    <rule type="collectionSize" context="delete">
        <param name="max" value="0" />
    </rule>
</property>
```

This rule is for our "Product Type" orm entity in an eCommerce application.  Before we delete, I want to make sure that the one-to-many relationship of products is an empty array so that I don't leave any products out there without a product type.

I hope that this example makes sense.

-Greg
